### PR TITLE
Release 0.3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.4" %}
+{% set version = "0.3.5" %}
 
 package:
   name: glog
@@ -7,10 +7,10 @@ package:
 source:
   fn: glog-{{ version }}.tar.gz
   url: https://github.com/google/glog/archive/v{{ version }}.tar.gz
-  sha256: ce99d58dce74458f7656a68935d7a0c048fa7b4626566a71b7f4e545920ceb10
+  sha256: 7580e408a2c0b5a89ca214739978ce6ff480b5e7d8d7698a2aa92fadc484d1e0
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
```markdown
### google-glog 0.3.5

* CHECK_NOTNULL works with smart pointers when compiled in C++11
* Add \_\_declspec(noreturn) on Win
* DCHECK_ALWAYS_ON to make D\* enabled under NDEBUG
* MinGW: avoid the error "conflicting declaration 'typedef DWORD pthread_t'" etc.
* NULL sinks_ after deletion to prevent dangling pointer
* Symbolize: Calculate a module's zero VA using program headers
* Allow permission line in /proc/self/map to be "rwx"
* Add support for PowerPC
* Use namespace GFLAGS_NAMESPACE instead namespace gflags. #62
* Win: use \_fdopen instead of fdopen. Fix #73
* Win: FAILED macro can't be used with HANDLE. Fix #79
* Avoid calling new/malloc in signalhandler to fix #78
* Reset SIGABRT action only if FailureSignalHandler is installed
* Fix missing public include directory
* Fix double-free in unit test on Windows
* Add logfile_mode to control logfile permissions to fix #23
* Fix mocklog unused arguments
* Fix redefinition of \_XOPEN_SOURCE
* Don't call RAW_VLOG with locking vmodule_lock to fix #29
* Add CMake support. closes #4
* Fix #8 AddLogSink memory leak
* Add #ifndefs to avoid collision with other google opensource projects
* LOG_STRING: use std::vector and std::string
* Adds color output support for tmux terminals
* Fix x64/Debug build on MSVS
```